### PR TITLE
Update HTTP/3 frames number

### DIFF
--- a/en/h3-streams.md
+++ b/en/h3-streams.md
@@ -9,7 +9,7 @@ HTTP requests done over HTTP/3 use a specific set of streams.
 ## HTTP/3 frames
 
 HTTP/3 means setting up QUIC streams and sending over a set of frames to the
-other end. There's but a small fixed number (eight!) of known frames in
+other end. There's but a small fixed number (actually nine the December 18, 2018!) of known frames in
 HTTP/3. The most important ones are probably:
 
 - HEADERS, that sends compressed HTTP headers

--- a/en/h3-streams.md
+++ b/en/h3-streams.md
@@ -9,7 +9,7 @@ HTTP requests done over HTTP/3 use a specific set of streams.
 ## HTTP/3 frames
 
 HTTP/3 means setting up QUIC streams and sending over a set of frames to the
-other end. There's but a small fixed number (actually nine the December 18, 2018!) of known frames in
+other end. There's but a small fixed number (actually nine on December 18th, 2018!) of known frames in
 HTTP/3. The most important ones are probably:
 
 - HEADERS, that sends compressed HTTP headers


### PR DESCRIPTION
The IETF 17th Internet draft for "Using TLS to Secure QUIC" added a new frame type: `DUPLICATE_PUSH`. So now it's not height frames anymore but nine

To prevent this issue, I has reformulated the sentence as `actually nine on December 18th, 2018!`.