### PR TITLE
Fix: broken link to license

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -42,4 +42,4 @@ github page.
 ## License
 
 This document and all its contents are licensed under the [Creative Commons
-Attribution 4.0 license](https://creativecommons.org/licenses/by/4.0w/).
+Attribution 4.0 license](https://creativecommons.org/licenses/by/4.0/).

--- a/fr/README.md
+++ b/fr/README.md
@@ -42,4 +42,4 @@ livre.
 ## Licence
 
 Ce document et tout son contenu sont sous licencés sous la [licence Creative Commons
-Attribution 4.0](https://creativecommons.org/licenses/by/4.0w/).
+Attribution 4.0](https://creativecommons.org/licenses/by/4.0/).

--- a/ja/README.md
+++ b/ja/README.md
@@ -50,4 +50,4 @@ Daniel は20年以上にわたり HTTP やインターネットのプロトコ�
 
 ## License
 
-この文書およびすべてのコンテンツは、[Creative Commons Attribution 4.0 license](https://creativecommons.org/licenses/by/4.0w/) のライセンスにて使用許諾されています。
+この文書およびすべてのコンテンツは、[Creative Commons Attribution 4.0 license](https://creativecommons.org/licenses/by/4.0/) のライセンスにて使用許諾されています。

--- a/zh/README.md
+++ b/zh/README.md
@@ -26,4 +26,4 @@
 
 ## 许可协议
 
-本文档及其所有内容遵循[知识共享 署名 4.0 许可协议](https://creativecommons.org/licenses/by/4.0w/)授权。
+本文档及其所有内容遵循[知识共享 署名 4.0 许可协议](https://creativecommons.org/licenses/by/4.0/)授权。


### PR DESCRIPTION
Could not access CC BY 4.0 license page via link in README.
Is it a typo?