### PR TITLE
[en] rephrase RFC terms

### DIFF
--- a/en/criticism.md
+++ b/en/criticism.md
@@ -10,8 +10,8 @@ attacks where one attacker can make a huge amount of outgoing traffic to
 target innocent victims.
 
 QUIC has built-in mitigation against amplification attacks by requiring that the
-initial packet MUST be at least 1200 bytes and by restriction in the protocol
-that says that a server MUST NOT send more than three times the size of the
+initial packet must be at least 1200 bytes and by restriction in the protocol
+that says that a server must not send more than three times the size of the
 request in response without receiving a packet from the client in response.
 
 ## UDP is slow in kernels

--- a/en/criticism.md
+++ b/en/criticism.md
@@ -10,7 +10,7 @@ attacks where one attacker can make a huge amount of outgoing traffic to
 target innocent victims.
 
 QUIC has built-in mitigation against amplification attacks by requiring that the
-initial packet must be at least 1200 bytes and by restriction in the protocol
+initial packet MUST be at least 1200 bytes and by restriction in the protocol
 that says that a server MUST NOT send more than three times the size of the
 request in response without receiving a packet from the client in response.
 


### PR DESCRIPTION
The MUST keyword is used in the [IETF I-D](https://tools.ietf.org/html/draft-ietf-quic-transport-22#section-8.1).