### PR TITLE
update draft urls

### DIFF
--- a/en/specs.md
+++ b/en/specs.md
@@ -5,19 +5,19 @@ components of QUIC and HTTP/3.
 
 ## Invariants
 
-[Version-Independent Properties of QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-06)
+[Version-Independent Properties of QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
 
 ## Transport
 
-[QUIC: A UDP-Based Multiplexed and Secure Transport](https://tools.ietf.org/html/draft-ietf-quic-transport-22)
+[QUIC: A UDP-Based Multiplexed and Secure Transport](https://tools.ietf.org/html/draft-ietf-quic-transport-23)
 
 ## Recovery
 
-[QUIC Loss Detection and Congestion Control](https://tools.ietf.org/html/draft-ietf-quic-recovery-22)
+[QUIC Loss Detection and Congestion Control](https://tools.ietf.org/html/draft-ietf-quic-recovery-23)
 
 ## TLS
 
-[Using Transport Layer Security (TLS) to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-22)
+[Using Transport Layer Security (TLS) to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-23)
 
 ## HTTP
 

--- a/fr/specs.md
+++ b/fr/specs.md
@@ -5,19 +5,19 @@ composants de QUIC et de HTTP/3.
 
 ## Invariants
 
-[Version-Independent Properties of QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-06)
+[Version-Independent Properties of QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
 
 ## Transport
 
-[QUIC: A UDP-Based Multiplexed and Secure Transport](https://tools.ietf.org/html/draft-ietf-quic-transport-22)
+[QUIC: A UDP-Based Multiplexed and Secure Transport](https://tools.ietf.org/html/draft-ietf-quic-transport-23)
 
 ## Récupération
 
-[QUIC Loss Detection and Congestion Control](https://tools.ietf.org/html/draft-ietf-quic-recovery-22)
+[QUIC Loss Detection and Congestion Control](https://tools.ietf.org/html/draft-ietf-quic-recovery-23)
 
 ## TLS
 
-[Using Transport Layer Security (TLS) to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-22)
+[Using Transport Layer Security (TLS) to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-23)
 
 ## HTTP
 

--- a/it/specs.md
+++ b/it/specs.md
@@ -5,19 +5,19 @@ pezzi e componenti di QUIC e HTTP/3.
 
 ## Invarianti (Costanti)
 
-[Proprietà di QUIC indipendenti dalla versione](https://tools.ietf.org/html/draft-ietf-quic-invariants-06)
+[Proprietà di QUIC indipendenti dalla versione](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
 
 ## Trasporto
 
-[QUIC: un trasporto "multiplexato" e sicuro basato su UDP](https://tools.ietf.org/html/draft-ietf-quic-transport-22)
+[QUIC: un trasporto "multiplexato" e sicuro basato su UDP](https://tools.ietf.org/html/draft-ietf-quic-transport-23)
 
 ## Recupero ("recovery")
 
-[Rilevamento delle perdite e controllo della congestione in QUIC](https://tools.ietf.org/html/draft-ietf-quic-recovery-22)
+[Rilevamento delle perdite e controllo della congestione in QUIC](https://tools.ietf.org/html/draft-ietf-quic-recovery-23)
 
 ## TLS
 
-[Usare TLS (sicurezza a livello di trasporto) per securizzare QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-22)
+[Usare TLS (sicurezza a livello di trasporto) per securizzare QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-23)
 
 ## HTTP
 

--- a/ja/specs.md
+++ b/ja/specs.md
@@ -3,19 +3,19 @@
 
 ## Invariants (不変事項)
 
-[Version-Independent Properties of QUIC (バージョンに依存しない QUIC の要素)](https://tools.ietf.org/html/draft-ietf-quic-invariants-06)
+[Version-Independent Properties of QUIC (バージョンに依存しない QUIC の要素)](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
 
 ## Transport (トランスポート プロトコル)
 
-[QUIC: A UDP-Based Multiplexed and Secure Transport (QUIC: UDP をベースにした多重でセキュアなトランスポートプロトコル)](https://tools.ietf.org/html/draft-ietf-quic-transport-22)
+[QUIC: A UDP-Based Multiplexed and Secure Transport (QUIC: UDP をベースにした多重でセキュアなトランスポートプロトコル)](https://tools.ietf.org/html/draft-ietf-quic-transport-23)
 
 ## Recovery (パケットの修復)
 
-[QUIC Loss Detection and Congestion Control (QUIC のパケットロスの検知機能と輻輳制御)](https://tools.ietf.org/html/draft-ietf-quic-recovery-22)
+[QUIC Loss Detection and Congestion Control (QUIC のパケットロスの検知機能と輻輳制御)](https://tools.ietf.org/html/draft-ietf-quic-recovery-23)
 
 ## TLS
 
-[Using Transport Layer Security (TLS) to Secure QUIC (TLS を用いたセキュアな QUIC)](https://tools.ietf.org/html/draft-ietf-quic-tls-22)
+[Using Transport Layer Security (TLS) to Secure QUIC (TLS を用いたセキュアな QUIC)](https://tools.ietf.org/html/draft-ietf-quic-tls-23)
 
 ## HTTP
 

--- a/ko/specs.md
+++ b/ko/specs.md
@@ -6,19 +6,19 @@ components of QUIC and HTTP/3.
 
 ## Invariants
 
-[Version-Independent Properties of QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-06)
+[Version-Independent Properties of QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
 
 ## Transport
 
-[QUIC: A UDP-Based Multiplexed and Secure Transport](https://tools.ietf.org/html/draft-ietf-quic-transport-22)
+[QUIC: A UDP-Based Multiplexed and Secure Transport](https://tools.ietf.org/html/draft-ietf-quic-transport-23)
 
 ## Recovery
 
-[QUIC Loss Detection and Congestion Control](https://tools.ietf.org/html/draft-ietf-quic-recovery-22)
+[QUIC Loss Detection and Congestion Control](https://tools.ietf.org/html/draft-ietf-quic-recovery-23)
 
 ## TLS
 
-[Using Transport Layer Security (TLS) to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-22)
+[Using Transport Layer Security (TLS) to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-23)
 
 ## HTTP
 
@@ -35,19 +35,19 @@ components of QUIC and HTTP/3.
 
 ## 불변
 
-[QUIC의 버전 독립적인 프로퍼티](https://tools.ietf.org/html/draft-ietf-quic-invariants-06)
+[QUIC의 버전 독립적인 프로퍼티](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
 
 ## 전송
 
-[QUIC: UDP에 기반을 둔 멀티플랙싱 보안 전송](https://tools.ietf.org/html/draft-ietf-quic-transport-22)
+[QUIC: UDP에 기반을 둔 멀티플랙싱 보안 전송](https://tools.ietf.org/html/draft-ietf-quic-transport-23)
 
 ## 복구
 
-[QUIC 손실 탐지와 혼잡 제어](https://tools.ietf.org/html/draft-ietf-quic-recovery-22)
+[QUIC 손실 탐지와 혼잡 제어](https://tools.ietf.org/html/draft-ietf-quic-recovery-23)
 
 ## TLS
 
-[Transport Layer Security(TLS)를 사용해서 QUIC 안전하게 하기](https://tools.ietf.org/html/draft-ietf-quic-tls-22)
+[Transport Layer Security(TLS)를 사용해서 QUIC 안전하게 하기](https://tools.ietf.org/html/draft-ietf-quic-tls-23)
 
 ## HTTP
 

--- a/ro/specs.md
+++ b/ro/specs.md
@@ -5,19 +5,19 @@ componente ale QUIC și HTTP/3.
 
 ## Invariante
 
-[Proprietățile independente de versiune ale QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-06)
+[Proprietățile independente de versiune ale QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
 
 ## Transfer
 
-[QUIC: Un transfer multiplexed și sigur bazat pe UDP](https://tools.ietf.org/html/draft-ietf-quic-transport-22)
+[QUIC: Un transfer multiplexed și sigur bazat pe UDP](https://tools.ietf.org/html/draft-ietf-quic-transport-23)
 
 ## Recuperare
 
-[Detectarea pierderilor și control congestiilor în QUIC](https://tools.ietf.org/html/draft-ietf-quic-recovery-22)
+[Detectarea pierderilor și control congestiilor în QUIC](https://tools.ietf.org/html/draft-ietf-quic-recovery-23)
 
 ## TLS
 
-[Folosirea TLS pentru a securiza QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-22)
+[Folosirea TLS pentru a securiza QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-23)
 
 ## HTTP
 

--- a/zh/specs.md
+++ b/zh/specs.md
@@ -4,19 +4,19 @@
 
 ## 不变性
 
-[Version-Independent Properties of QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-06)
+[Version-Independent Properties of QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
 
 ## 传输层
 
-[QUIC: A UDP-Based Multiplexed and Secure Transport](https://tools.ietf.org/html/draft-ietf-quic-transport-22)
+[QUIC: A UDP-Based Multiplexed and Secure Transport](https://tools.ietf.org/html/draft-ietf-quic-transport-23)
 
 ## 自动恢复
 
-[QUIC Loss Detection and Congestion Control](https://tools.ietf.org/html/draft-ietf-quic-recovery-22)
+[QUIC Loss Detection and Congestion Control](https://tools.ietf.org/html/draft-ietf-quic-recovery-23)
 
 ## TLS
 
-[Using Transport Layer Security (TLS) to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-22)
+[Using Transport Layer Security (TLS) to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-23)
 
 ## HTTP
 


### PR DESCRIPTION
Note: Hypertext Transfer Protocol (HTTP) over QUIC and QPACK: Header Compression for HTTP over QUIC have not been updated as of now.