### PR TITLE
Remove confusing mention of Firefox

### DIFF
--- a/en/why-h2.md
+++ b/en/why-h2.md
@@ -5,7 +5,7 @@ published in May 2015 and the protocol has since then been implemented and
 deployed widely across the Internet and the World Wide Web.
 
 In early 2018, almost 40% of the top-1000 web sites run HTTP/2, around 70% of
-all HTTPS requests Firefox issues get HTTP/2 responses back and all major
+all HTTPS requests get HTTP/2 responses back, and all major
 browsers, servers and proxies support it.
 
 HTTP/2 addresses a whole slew of shortcomings in HTTP/1 and with the


### PR DESCRIPTION
This is a speculative change, because the sentence seems to make no sense, and removing the words "Firefox issues" seems to solve it. If somehow "Firefox issues" are relevant to those statistics, then some other fix will be more appropriate!