### PR TITLE
Remove version numbers from specs

### DIFF
--- a/en/specs.md
+++ b/en/specs.md
@@ -17,7 +17,7 @@ components of QUIC and HTTP/3.
 
 ## TLS
 
-[Using TLS to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-27)
+[Using TLS to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls)
 
 ## HTTP
 

--- a/fa/specs.md
+++ b/fa/specs.md
@@ -4,24 +4,24 @@
 
 ## نامتغیر‌ها
 
-[دارایی‌های غیروابسته به نسخه و مستقل پروتکل QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
+[دارایی‌های غیروابسته به نسخه و مستقل پروتکل QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants)
 
 ## انتقال
 
-[پروتکل QUIC: یک انتقال امن و چندگانه‌ی UDP محور](https://tools.ietf.org/html/draft-ietf-quic-transport-27)
+[پروتکل QUIC: یک انتقال امن و چندگانه‌ی UDP محور](https://tools.ietf.org/html/draft-ietf-quic-transport)
 
 ## بازیابی
 
-[تشخیص اتلاف و کنترل تراکم پروتکل QUIC](https://tools.ietf.org/html/draft-ietf-quic-recovery-27)
+[تشخیص اتلاف و کنترل تراکم پروتکل QUIC](https://tools.ietf.org/html/draft-ietf-quic-recovery)
 
 ## امنیت لایه انتقال
 
-[استفاده از TLS برای امن‌سازی پروتکل QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-27)
+[استفاده از TLS برای امن‌سازی پروتکل QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls)
 
 ## پروتکل انتقال ابرمتن
 
-[پروتکل انتقال ابرمتن نسخه ۳ (HTTP/3)](https://tools.ietf.org/html/draft-ietf-quic-http-27)
+[پروتکل انتقال ابرمتن نسخه ۳ (HTTP/3)](https://tools.ietf.org/html/draft-ietf-quic-http)
 
 ## روش فشرده‌سازی سرایند QPACK
 
-[روش QPACK: فشرده‌سازی سرایند برای HTTP/3](https://tools.ietf.org/html/draft-ietf-quic-qpack-14)
+[روش QPACK: فشرده‌سازی سرایند برای HTTP/3](https://tools.ietf.org/html/draft-ietf-quic-qpack)

--- a/fr/specs.md
+++ b/fr/specs.md
@@ -5,24 +5,24 @@ composants de QUIC et de HTTP/3.
 
 ## Invariants
 
-[Version-Independent Properties of QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
+[Version-Independent Properties of QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants)
 
 ## Transport
 
-[QUIC: A UDP-Based Multiplexed and Secure Transport](https://tools.ietf.org/html/draft-ietf-quic-transport-27)
+[QUIC: A UDP-Based Multiplexed and Secure Transport](https://tools.ietf.org/html/draft-ietf-quic-transport)
 
 ## Récupération
 
-[QUIC Loss Detection and Congestion Control](https://tools.ietf.org/html/draft-ietf-quic-recovery-27)
+[QUIC Loss Detection and Congestion Control](https://tools.ietf.org/html/draft-ietf-quic-recovery)
 
 ## TLS
 
-[Using Transport Layer Security (TLS) to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-27)
+[Using Transport Layer Security (TLS) to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls)
 
 ## HTTP
 
-[Hypertext Transfer Protocol (HTTP) over QUIC](https://tools.ietf.org/html/draft-ietf-quic-http-27)
+[Hypertext Transfer Protocol (HTTP) over QUIC](https://tools.ietf.org/html/draft-ietf-quic-http)
 
 ## QPACK
 
-[QPACK: Header Compression for HTTP over QUIC](https://tools.ietf.org/html/draft-ietf-quic-qpack-14)
+[QPACK: Header Compression for HTTP over QUIC](https://tools.ietf.org/html/draft-ietf-quic-qpack)

--- a/it/specs.md
+++ b/it/specs.md
@@ -5,24 +5,24 @@ pezzi e componenti di QUIC e HTTP/3.
 
 ## Invarianti (Costanti)
 
-[Proprietà di QUIC indipendenti dalla versione](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
+[Proprietà di QUIC indipendenti dalla versione](https://tools.ietf.org/html/draft-ietf-quic-invariants)
 
 ## Trasporto
 
-[QUIC: un trasporto "multiplexato" e sicuro basato su UDP](https://tools.ietf.org/html/draft-ietf-quic-transport-27)
+[QUIC: un trasporto "multiplexato" e sicuro basato su UDP](https://tools.ietf.org/html/draft-ietf-quic-transport)
 
 ## Recupero ("recovery")
 
-[Rilevamento delle perdite e controllo della congestione in QUIC](https://tools.ietf.org/html/draft-ietf-quic-recovery-27)
+[Rilevamento delle perdite e controllo della congestione in QUIC](https://tools.ietf.org/html/draft-ietf-quic-recovery)
 
 ## TLS
 
-[Usare TLS (sicurezza a livello di trasporto) per securizzare QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-27)
+[Usare TLS (sicurezza a livello di trasporto) per securizzare QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls)
 
 ## HTTP
 
-[Protocollo di trasferimento di ipertesto (HTTP) via QUIC](https://tools.ietf.org/html/draft-ietf-quic-http-27)
+[Protocollo di trasferimento di ipertesto (HTTP) via QUIC](https://tools.ietf.org/html/draft-ietf-quic-http)
 
 ## QPACK
 
-[QPACK: Compressione degli Header per HTTP via QUIC](https://tools.ietf.org/html/draft-ietf-quic-qpack-14)
+[QPACK: Compressione degli Header per HTTP via QUIC](https://tools.ietf.org/html/draft-ietf-quic-qpack)

--- a/ja/specs.md
+++ b/ja/specs.md
@@ -3,24 +3,24 @@
 
 ## Invariants (不変事項)
 
-[Version-Independent Properties of QUIC (バージョンに依存しない QUIC の要素)](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
+[Version-Independent Properties of QUIC (バージョンに依存しない QUIC の要素)](https://tools.ietf.org/html/draft-ietf-quic-invariants)
 
 ## Transport (トランスポート プロトコル)
 
-[QUIC: A UDP-Based Multiplexed and Secure Transport (QUIC: UDP をベースにした多重でセキュアなトランスポートプロトコル)](https://tools.ietf.org/html/draft-ietf-quic-transport-27)
+[QUIC: A UDP-Based Multiplexed and Secure Transport (QUIC: UDP をベースにした多重でセキュアなトランスポートプロトコル)](https://tools.ietf.org/html/draft-ietf-quic-transport)
 
 ## Recovery (パケットの修復)
 
-[QUIC Loss Detection and Congestion Control (QUIC のパケットロスの検知機能と輻輳制御)](https://tools.ietf.org/html/draft-ietf-quic-recovery-27)
+[QUIC Loss Detection and Congestion Control (QUIC のパケットロスの検知機能と輻輳制御)](https://tools.ietf.org/html/draft-ietf-quic-recovery)
 
 ## TLS
 
-[Using TLS to Secure QUIC (TLS を用いたセキュアな QUIC)](https://tools.ietf.org/html/draft-ietf-quic-tls-27)
+[Using TLS to Secure QUIC (TLS を用いたセキュアな QUIC)](https://tools.ietf.org/html/draft-ietf-quic-tls)
 
 ## HTTP
 
-[Hypertext Transfer Protocol Version 3 (HTTP/3)](https://tools.ietf.org/html/draft-ietf-quic-http-27)
+[Hypertext Transfer Protocol Version 3 (HTTP/3)](https://tools.ietf.org/html/draft-ietf-quic-http)
 
 ## QPACK
 
-[QPACK: Header Compression for HTTP/3 (QPACK: HTTP/3 のためのヘッダー圧縮方法)](https://tools.ietf.org/html/draft-ietf-quic-qpack-14)
+[QPACK: Header Compression for HTTP/3 (QPACK: HTTP/3 のためのヘッダー圧縮方法)](https://tools.ietf.org/html/draft-ietf-quic-qpack)

--- a/ko/specs.md
+++ b/ko/specs.md
@@ -6,27 +6,27 @@ components of QUIC and HTTP/3.
 
 ## Invariants
 
-[Version-Independent Properties of QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
+[Version-Independent Properties of QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants)
 
 ## Transport
 
-[QUIC: A UDP-Based Multiplexed and Secure Transport](https://tools.ietf.org/html/draft-ietf-quic-transport-27)
+[QUIC: A UDP-Based Multiplexed and Secure Transport](https://tools.ietf.org/html/draft-ietf-quic-transport)
 
 ## Recovery
 
-[QUIC Loss Detection and Congestion Control](https://tools.ietf.org/html/draft-ietf-quic-recovery-27)
+[QUIC Loss Detection and Congestion Control](https://tools.ietf.org/html/draft-ietf-quic-recovery)
 
 ## TLS
 
-[Using Transport Layer Security (TLS) to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-27)
+[Using Transport Layer Security (TLS) to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls)
 
 ## HTTP
 
-[Hypertext Transfer Protocol (HTTP) over QUIC](https://tools.ietf.org/html/draft-ietf-quic-http-27)
+[Hypertext Transfer Protocol (HTTP) over QUIC](https://tools.ietf.org/html/draft-ietf-quic-http)
 
 ## QPACK
 
-[QPACK: Header Compression for HTTP over QUIC](https://tools.ietf.org/html/draft-ietf-quic-qpack-14)
+[QPACK: Header Compression for HTTP over QUIC](https://tools.ietf.org/html/draft-ietf-quic-qpack)
 -->
 
 # 명세
@@ -35,24 +35,24 @@ components of QUIC and HTTP/3.
 
 ## 불변
 
-[QUIC의 버전 독립적인 프로퍼티](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
+[QUIC의 버전 독립적인 프로퍼티](https://tools.ietf.org/html/draft-ietf-quic-invariants)
 
 ## 전송
 
-[QUIC: UDP에 기반을 둔 멀티플랙싱 보안 전송](https://tools.ietf.org/html/draft-ietf-quic-transport-27)
+[QUIC: UDP에 기반을 둔 멀티플랙싱 보안 전송](https://tools.ietf.org/html/draft-ietf-quic-transport)
 
 ## 복구
 
-[QUIC 손실 탐지와 혼잡 제어](https://tools.ietf.org/html/draft-ietf-quic-recovery-27)
+[QUIC 손실 탐지와 혼잡 제어](https://tools.ietf.org/html/draft-ietf-quic-recovery)
 
 ## TLS
 
-[Transport Layer Security(TLS)를 사용해서 QUIC 안전하게 하기](https://tools.ietf.org/html/draft-ietf-quic-tls-27)
+[Transport Layer Security(TLS)를 사용해서 QUIC 안전하게 하기](https://tools.ietf.org/html/draft-ietf-quic-tls)
 
 ## HTTP
 
-[QUIC을 통한 Hypertext Transfer Protocol(HTTP)](https://tools.ietf.org/html/draft-ietf-quic-http-27)
+[QUIC을 통한 Hypertext Transfer Protocol(HTTP)](https://tools.ietf.org/html/draft-ietf-quic-http)
 
 ## QPACK
 
-[QPACK: QUIC을 통한 HTTP의 헤더 압축](https://tools.ietf.org/html/draft-ietf-quic-qpack-14)
+[QPACK: QUIC을 통한 HTTP의 헤더 압축](https://tools.ietf.org/html/draft-ietf-quic-qpack)

--- a/ro/specs.md
+++ b/ro/specs.md
@@ -5,24 +5,24 @@ componente ale QUIC și HTTP/3.
 
 ## Invariante
 
-[Proprietățile independente de versiune ale QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
+[Proprietățile independente de versiune ale QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants)
 
 ## Transfer
 
-[QUIC: Un transfer multiplexed și sigur bazat pe UDP](https://tools.ietf.org/html/draft-ietf-quic-transport-27)
+[QUIC: Un transfer multiplexed și sigur bazat pe UDP](https://tools.ietf.org/html/draft-ietf-quic-transport)
 
 ## Recuperare
 
-[Detectarea pierderilor și control congestiilor în QUIC](https://tools.ietf.org/html/draft-ietf-quic-recovery-27)
+[Detectarea pierderilor și control congestiilor în QUIC](https://tools.ietf.org/html/draft-ietf-quic-recovery)
 
 ## TLS
 
-[Folosirea TLS pentru a securiza QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-27)
+[Folosirea TLS pentru a securiza QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls)
 
 ## HTTP
 
-[Hypertext Transfer Protocol (HTTP) peste QUIC](https://tools.ietf.org/html/draft-ietf-quic-http-27)
+[Hypertext Transfer Protocol (HTTP) peste QUIC](https://tools.ietf.org/html/draft-ietf-quic-http)
 
 ## QPACK
 
-[QPACK: Compresia headere-lor HTTP peste QUIC](https://tools.ietf.org/html/draft-ietf-quic-qpack-14)
+[QPACK: Compresia headere-lor HTTP peste QUIC](https://tools.ietf.org/html/draft-ietf-quic-qpack)

--- a/zh/specs.md
+++ b/zh/specs.md
@@ -4,24 +4,24 @@
 
 ## 不变性
 
-[Version-Independent Properties of QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants-07)
+[Version-Independent Properties of QUIC](https://tools.ietf.org/html/draft-ietf-quic-invariants)
 
 ## 传输层
 
-[QUIC: A UDP-Based Multiplexed and Secure Transport](https://tools.ietf.org/html/draft-ietf-quic-transport-27)
+[QUIC: A UDP-Based Multiplexed and Secure Transport](https://tools.ietf.org/html/draft-ietf-quic-transport)
 
 ## 自动恢复
 
-[QUIC Loss Detection and Congestion Control](https://tools.ietf.org/html/draft-ietf-quic-recovery-27)
+[QUIC Loss Detection and Congestion Control](https://tools.ietf.org/html/draft-ietf-quic-recovery)
 
 ## TLS
 
-[Using Transport Layer Security (TLS) to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls-27)
+[Using Transport Layer Security (TLS) to Secure QUIC](https://tools.ietf.org/html/draft-ietf-quic-tls)
 
 ## HTTP
 
-[Hypertext Transfer Protocol (HTTP) over QUIC](https://tools.ietf.org/html/draft-ietf-quic-http-27)
+[Hypertext Transfer Protocol (HTTP) over QUIC](https://tools.ietf.org/html/draft-ietf-quic-http)
 
 ## QPACK
 
-[QPACK: Header Compression for HTTP over QUIC](https://tools.ietf.org/html/draft-ietf-quic-qpack-14)
+[QPACK: Header Compression for HTTP over QUIC](https://tools.ietf.org/html/draft-ietf-quic-qpack)


### PR DESCRIPTION
When you don't provide a version number of IETF specs they automatically redirect to the latest version.

So, until these specs are finalised (at which point they will be renamed to remove draft from the names so will need to be updated anyway) let's just use the version-less URL to save having to do the below so often. Note this was already done to most of the English versions in #175 

![Commits showing version numbers being updated periodically](https://user-images.githubusercontent.com/10931297/84589925-215fb000-ae2a-11ea-9616-119b01b061a1.png)
