### PR TITLE
Grammar fix: German has no genitive apostrophe

### DIFF
--- a/de/proc.md
+++ b/de/proc.md
@@ -1,6 +1,6 @@
 # Prozess
 
-Das ursprüngliche QUIC Protokoll wurde von Jim Roskind bei Google entworfen, im Jahr 2012 erstmals implementiert und der Welt 2013 vorgestellt, als Google's Experiment erweitert wurde.
+Das ursprüngliche QUIC Protokoll wurde von Jim Roskind bei Google entworfen, im Jahr 2012 erstmals implementiert und der Welt 2013 vorgestellt, als Googles Experiment erweitert wurde.
 
 Damals galt QUIC noch als Akronym für "Quick UDP Internet Connections", aber das wurde seitdem eingestellt.
 


### PR DESCRIPTION
(If this is a citiation of an English name, it should be written in quotes instead, i.e. `"Google's Experiment"`)

Also fixes a missing new line at the end of the file, but this wasn't me, that was Github's online file editor (but not clearly visible in its online diff viewer). Since I consider this change by accident still a good one, I left it as it is.