### PR TITLE
en/quic-v2.md: v2 already exists

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -37,7 +37,7 @@
         * [Comparison with HTTP/2](en/h3-h2.md)
     * [Common criticism](en/criticism.md)
     * [The specifications](en/specs.md)
-    * [QUIC v2](en/quic-v2.md)
+    * [QUIC future](en/quic-future.md)
 
 * [Español](es/README.md)
     * [Por qué QUIC](es/why-quic.md)

--- a/en/quic-future.md
+++ b/en/quic-future.md
@@ -1,15 +1,15 @@
-# QUIC v2
+# QUIC future
 
 In order to get the most possibly focus on the core QUIC protocol and be able
 to ship it on time, several features that were originally planned to be part
 of the core protocol have been postponed and are now planned to instead get
-done in a subsequent QUIC version. QUIC version 2 or beyond.
+done in a subsequent QUIC version.
 
 The author of this document does however have a rather faulty crystal ball so
-we can not tell for sure exactly what features will or will not appear in
-version 2. We can however mention some of the features and things that
+we can not tell for sure exactly what features will or will not appear in such
+a future version. We can however mention some of the features and things that
 explicitly have been removed from the v1 work to be "worked on later" and that
-then possibly might appear in a version 2.
+then possibly might appear in a future version.
 
 ## Forward Error Correction
 
@@ -19,8 +19,8 @@ recognizes only the portion of the data that contains no apparent errors.
 
 Google experimented with this in their original QUIC work but it was
 subsequently removed again since the experiments did not turn out well. This
-feature is subject for discussion for QUIC v2 but probably takes for someone
-to prove that it actually can be a useful addition without too much penalty.
+feature is subject for discussion for QUIC but probably takes for someone to
+prove that it actually can be a useful addition without too much penalty.
 
 ## Multipath
 


### PR DESCRIPTION
Call the section "QUIC future" instead.

Fixes #235
Report-by: Martin Thomson