### PR TITLE
[minor fix] README.md: replace hyperlink description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 QUIC protocols. Join in and help!
 
 Get the Web or PDF versions on
-[gitbook.com](https://http3-explained.haxx.se/).
+[http3-explained.haxx.se](https://http3-explained.haxx.se/).
 
 The contents get updated automatically on every commit to this git repository.
 


### PR DESCRIPTION
"Get the web or pdf versions on gitbook.com" would imply that the URL points to `gitbook.com` (as most readers would expect), but since the URL acutally points to `http3-explained.haxx.se`. So the description of the hyperlink is updated to match the URL destination to avoid confusion for readers.